### PR TITLE
Update PHP Version + add common libraries

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -8,28 +8,32 @@
 # Same AL version as Lambda execution environment AMI
 FROM amazonlinux:2017.03.1.20170812 as builder
 
+# Set desired PHP Version
+ARG php_version="7.3.3"
+
 # Lock to 2017.03 release (same as Lambda) and install compilation dependencies
 RUN sed -i 's;^releasever.*;releasever=2017.03;;' /etc/yum.conf && \
     yum clean all && \
     yum install -y autoconf \
                 bison \
+                bzip2-devel \
                 gcc \
                 gcc-c++ \
-                make \
+                git \
+                gzip \
                 libcurl-devel \
                 libxml2-devel \
+                make \
                 openssl-devel \
                 tar \
-                gzip \
-                zip \
                 unzip \
-                git
+                zip
 
-# Download the PHP 7.3.0 source, compile, and install both PHP and Composer
-RUN curl -sL https://github.com/php/php-src/archive/php-7.3.0.tar.gz | tar -xvz && \
-    cd php-src-php-7.3.0 && \
+# Download the PHP source, compile, and install both PHP and Composer
+RUN curl -sL https://github.com/php/php-src/archive/php-${php_version}.tar.gz | tar -xvz && \
+    cd php-src-php-${php_version} && \
     ./buildconf --force && \
-    ./configure --prefix=/opt/php-7-bin/ --with-openssl --with-curl --with-zlib --without-pear && \
+    ./configure --prefix=/opt/php-7-bin/ --with-openssl --with-curl --with-zlib --without-pear --enable-bcmath --with-bz2 --enable-mbstring --with-mysqli && \
     make install && \
     /opt/php-7-bin/bin/php -v && \
     curl -sS https://getcomposer.org/installer | /opt/php-7-bin/bin/php -- --install-dir=/opt/php-7-bin/bin/ --filename=composer


### PR DESCRIPTION
* update PHP to latest stable release 7.3.0 => 7.3.3
* alpha sort yum-installed packages
* add a few more common PHP extensions, including bzip + bzip2-devel

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.