### PR TITLE
Update Guzzle call in PHP runtime

### DIFF
--- a/example/function/src/goodbye.php
+++ b/example/function/src/goodbye.php
@@ -5,7 +5,9 @@
 
 function goodbye($data)
 {
-    return "Goodbye, {$data['name']}!";
+    $response = [
+        'msg' => "Goodbye, {$data['name']}!",
+        'data' => $data
+    ];
+    return $response;
 }
-
-?>

--- a/example/function/src/hello.php
+++ b/example/function/src/hello.php
@@ -5,7 +5,9 @@
 
 function hello($data)
 {
-    return "Hello, {$data['name']}!";
+    $response = [
+        'msg' => "Hello, {$data['name']}!",
+        'data' => $data
+    ];
+    return $response;
 }
-
-?>

--- a/example/runtime/bootstrap
+++ b/example/runtime/bootstrap
@@ -22,8 +22,8 @@ function sendResponse($invocationId, $response)
 {
     $client = new \GuzzleHttp\Client();
     $client->post(
-    'http://' . $_ENV['AWS_LAMBDA_RUNTIME_API'] . '/2018-06-01/runtime/invocation/' . $invocationId . '/response',
-       ['body' => $response]
+      'http://' . $_ENV['AWS_LAMBDA_RUNTIME_API'] . '/2018-06-01/runtime/invocation/' . $invocationId . '/response',
+      ['body' => json_encode($response)]
     );
 }
 
@@ -42,5 +42,3 @@ do {
     // Submit the response back to the runtime API.
     sendResponse($request['invocationId'], $response);
 } while (true);
-
-?>


### PR DESCRIPTION
Guzzle v6 doesn't like POST w/ body of string or arbitrary types. It seems to throw FATAL errors. 

https://stackoverflow.com/a/38060763

* Update example PHP runtime with changes requested by guzzle tool,
  which as of v6 deprecates use of POST'ing body in this way
* Replaced by simply `json_encode()`ing the response payload and
  updating the hello/goodbye example functions to provide array output

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.