### PR TITLE
 Modifications to Dockerfile and .dockerignore to allow docker image to build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .git
 bin
 output
-img2lambda
 AUTHORS.md
 CONTRIBUTING.md
 LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@
 
 FROM golang:1.11 AS builder
 
-WORKDIR /go/src/github.com/awslabs/img2lambda
+WORKDIR /go/src/github.com/awslabs/aws-lambda-container-image-converter
 
 COPY . ./
+
 RUN make install-deps && make
 
 FROM busybox:glibc
-COPY --from=builder /go/src/github.com/awslabs/img2lambda/bin/local/img2lambda /bin/img2lambda
+COPY --from=builder /go/src/github.com/awslabs/aws-lambda-container-image-converter/bin/local/img2lambda /bin/img2lambda
 CMD [ "/bin/img2lambda" ]


### PR DESCRIPTION
I ran into a couple minor issues trying to build the docker image from source, this PR resolved the issues with building locally.

*Issue #, if available:*

*Description of changes:*
 * Modify .dockerignore file so it will copy the img2lambda source
 * Modify the WORKDIR and binary path in Dockerfile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
