### PR TITLE
More portable setup scripts

### DIFF
--- a/scripts/build_binary.sh
+++ b/scripts/build_binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -e
 
@@ -6,7 +6,7 @@ set -e
 # SPDX-License-Identifier: MIT-0
 
 # Normalize to working directory being build root (up one level from ./scripts)
-ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+ROOT="$GOPATH/src/github.com/awslabs/aws-lambda-container-image-converter/"
 cd "${ROOT}"
 
 # Builds the binary from source in the specified destination paths.


### PR DESCRIPTION
* update shebang
* busybox and ash and others don't use BASH_SOURCE, but this is all
  Golang so we can assume $GOPATH is set

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
