### PR TITLE
Add nodejs10.x to valid runtimes

### DIFF
--- a/img2lambda/types/types.go
+++ b/img2lambda/types/types.go
@@ -66,6 +66,7 @@ var ValidRuntimes = Runtimes{
 	"nodejs4.3", // eol = 30/04/2018 but included to support existing versions
 	"nodejs6.10",
 	"nodejs8.10",
+	"nodejs10.x",
 	"java8",
 	"python2.7",
 	"python3.6",


### PR DESCRIPTION
*Issue [36](https://github.com/awslabs/aws-lambda-container-image-converter/issues/36)*

*Description of changes:*
Add node 10 to valid runtimes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
