### PR TITLE
Removed .git from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 bin
 output
 AUTHORS.md


### PR DESCRIPTION
Make files which get executed inside the docker needs .git to be there, hence this should not be ignored.

*Issue #, if available: **Running docker build fails!**
`# docker build . -t img2lambda`

> .
> .
> find: '.git/': No such file or directory
> .
> .

*Description of changes: 
removed .git from the .dockerignore file so the copy command inside the docker file copy the .git into the containers building.
_Tested it and it succeed after the change._


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
