### PR TITLE
Update README.md: Install all Go project dependencies in one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Download pre-built binaries from the [Releases Page](https://github.com/awslabs/
 $ mkdir -p $GOPATH/src/github.com/awslabs
 $ git clone https://github.com/awslabs/aws-lambda-container-image-converter $GOPATH/src/github.com/awslabs/aws-lambda-container-image-converter
 $ cd !$
+$ # Install all Go project dependencies in one command
+$ go get -v ./...
 $ make
 $ ./bin/local/img2lambda --help
 ```


### PR DESCRIPTION
added `go get -v ./...` command to tnstall all Go project dependencies in one command in [Install from Source section](https://github.com/awslabs/aws-lambda-container-image-converter/tree/1.2.0#from-source)